### PR TITLE
Storege,Workerでプロセス管理を強制的に削除する処理の実装

### DIFF
--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -44,4 +44,13 @@ interface StorageInterface
      */
     public function remove($queue, $server, $procId);
 
+
+    /**
+     * @param $queue
+     * @param $server
+     * @return void
+     */
+    public function removeForce($queue, $server);
+
+
 }

--- a/Tests/Worker/WorkerTest.php
+++ b/Tests/Worker/WorkerTest.php
@@ -77,6 +77,30 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
         Phake::verify($storage)->remove($name, "test.com", 1234);
 
     }
+
+    /**
+     * @test
+     */
+    public function ワーカーを強制的に停止させる()
+    {
+        $name = "test";
+        $entity = new TestEntity($name, 'test.com', 1234);
+
+        $queue = Phake::mock('Tavii\SQSJobQueue\Queue\Queue');
+        $storage = Phake::mock('Tavii\SQSJobQueue\Worker\TestStorage');
+        Phake::when($storage)->find($name, 'test.com', null)
+            ->thenReturn(array(
+                $entity
+            ));
+
+        $worker = new Worker($queue, $storage);
+        $worker->stop($name, null, true);
+
+        Phake::verify($storage)->find($name, "test.com", null);
+        Phake::verify($storage)->remove($name, "test.com", 1234);
+        Phake::verify($storage)->removeForce($name, "test.com");
+    }
+
 }
 
 
@@ -145,6 +169,12 @@ class TestStorage implements StorageInterface
     {
         // TODO: Implement remove() method.
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeForce($queue, $server) {}
+
 
 
 }

--- a/Worker/Worker.php
+++ b/Worker/Worker.php
@@ -68,7 +68,7 @@ class Worker implements WorkerInterface
     /**
      * {@inheritdoc}
      */
-    public function stop($name, $pid = null)
+    public function stop($name, $pid = null, $force = false)
     {
         if (function_exists('gethostname')) {
             $server = gethostname();
@@ -86,5 +86,10 @@ class Worker implements WorkerInterface
                 $this->storage->remove($process->getQueue(), $process->getServer(), $process->getProcId());
             }
         }
+
+        if ($force) {
+            $this->storage->removeForce($name, $server);
+        }
+
     }
 }

--- a/Worker/WorkerInterface.php
+++ b/Worker/WorkerInterface.php
@@ -24,7 +24,9 @@ interface WorkerInterface
     /**
      * 常駐しているワーカーを停止させる
      * @param string $name
+     * @param int $pid
+     * @param bool $force
      * @return void
      */
-    public function stop($name, $pid = null);
+    public function stop($name, $pid = null, $force = false);
 }


### PR DESCRIPTION
プロセスなくなった場合にストレージから解放されない問題を対応するために、Worker::stop()でプロセウがない場合に強制的にストレージから削除する処理を実装。
